### PR TITLE
Change the Web Server port 5000 to port 80

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "dev" do |dev|
     dev.vm.box = "bento/ubuntu-18.04"
-    dev.vm.network "forwarded_port", guest: 5000, host: 5000
+    dev.vm.network "forwarded_port", guest: 80, host: 80
   end
 
   config.vm.define "stage" do |stage|

--- a/app.py
+++ b/app.py
@@ -3,4 +3,4 @@
 from beyond import app
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True)
+    app.run(host='0.0.0.0', port=80, debug=True)

--- a/bootstrap-infra.py
+++ b/bootstrap-infra.py
@@ -16,8 +16,8 @@ def main():
     group_permissions = [
         {
             'IpProtocol': 'tcp',
-            'FromPort': 5000,
-            'ToPort': 5000,
+            'FromPort': 80,
+            'ToPort': 80,
             'IpRanges': [
                 {
                     'CidrIp': '0.0.0.0/0'

--- a/tests/functional/test_title.py
+++ b/tests/functional/test_title.py
@@ -2,5 +2,5 @@
 
 
 def test_title(selenium):
-    selenium.get('http://localhost:5000')
+    selenium.get('http://localhost:80')
     assert selenium.title == 'Beyond'

--- a/tests/http_get_test.sh
+++ b/tests/http_get_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 exp_response='200'
-if [ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:5000) = $exp_response ]; then
+if [ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:80) = $exp_response ]; then
   exit 0
 else
   exit 1

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -4,7 +4,7 @@ import requests
 
 
 def test_webserver_response_code():
-    response = requests.get("http://localhost:5000")
+    response = requests.get("http://localhost:80")
     assert response.status_code == 200
 
 


### PR DESCRIPTION
To be able to run our Web server on standard WWW port we are changing the code to support port 80 instead of port 5000.

Change the Web Server port 5000 to port 80 issue #167 

Changed has been done to the relevant files:
bootstrap-infra.py:            'FromPort': 80,
bootstrap-infra.py:            'ToPort': 80,
tests/test_sanity.py:    response = requests.get("http://localhost:80")
tests/functional/test_title.py:    selenium.get('http://localhost:80')
tests/http_get_test.sh:if [ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:80) = $exp_response ]; then
Vagrantfile:    dev.vm.network "forwarded_port", guest: 80, host: 80