### PR TITLE
Configure prod env to use static Elastic IP 

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -7,6 +7,7 @@ AMI_PROD='ami-0701e7be9b2a77600'
 INSTANCE_TYPE_PROD='t2.micro'
 REGION_PROD='eu-west-1'
 USERNAME_PROD='ubuntu'
+ELASTIC_IP='54.228.108.127'
 
 ### PROD AWS CERDENTIALS ###
 # AWS Subnet ID from the EC2 console Network Interface menu

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
       aws.region = ENV['REGION_PROD']
       aws.subnet_id = ENV['SUBNET_ID_PROD']
       aws.security_groups = ENV['SECURITY_GROUPS_PROD']
-      aws.associate_public_ip = true
+      aws.elastic_ip = ENV['ELASTIC_IP']
       override.ssh.username = ENV['USERNAME_PROD']
       override.ssh.private_key_path = ENV['PRIVATE_KEY_PATH_PROD']
     end


### PR DESCRIPTION
fix for: #169 
Added configuration to the PROD section of the Vagrant file, using the AWS plugin to configure it to use the Elastic IP record as IP address. The Elastic address was created manually on the AWS dashboard.
The actual IP address is store in an environment variable in the .env_template file and also needs to be added to each personal .env file.
