### PR TITLE
Added scheduled job to test our http status

### DIFF
--- a/.github/workflows/prod-health.yml
+++ b/.github/workflows/prod-health.yml
@@ -1,4 +1,4 @@
-name: Web-Access
+name: prod-health
 
 on:
   #runs twice a day
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Check http status code of production web-site
         uses: lakuapik/gh-actions-http-status@v1

--- a/.github/workflows/web-access.yml
+++ b/.github/workflows/web-access.yml
@@ -1,0 +1,17 @@
+name: Web-Access
+
+on:
+  #runs twice a day
+  schedule:
+    - cron:  '0 */12 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check http status code of production web-site
+        uses: lakuapik/gh-actions-http-status@v1
+        with:
+          sites: '["http://www.beyond-io.me.uk:5000"]'
+          expected: '[200]'


### PR DESCRIPTION
close #180 

Created schedule workflow in GitHub actions to check the HTTP code of our production environment, the workflow will run twice a day, will pass the test if it accepts a '200' code status that means 'OK' successful.  