### PR TITLE
Introduce docker-compose for building the image and running container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
         tar -xzf geckodriver-v0.26.0-linux64.tar.gz -C geckodriver
         pip install -r tests/requirements-test.txt
 
+    - name: Build the docker-compose stack
+      run: docker-compose up -d
+
     - name: Execute tests
       run: |
         pytest

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,10 @@ end
 Vagrant.require_version '= 2.2.10'
 
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins= ["vagrant-env"]
+  config.vagrant.plugins= ["vagrant-env", "vagrant-docker-compose"]
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [ "venv/", ".git/", ".idea/" ]
   config.vm.provision :docker
+  config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, run: "always"
   config.env.enable
 
   config.vm.provision "shell", path: "bootstrap.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+services:
+  beyond:
+    build: .
+    tty: true
+    container_name: beyond

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,3 +1,4 @@
-pytest==4.6.9
-pytest-selenium==1.17.0
+docker==4.4.0
 pystemd==0.8.0
+pytest-selenium==1.17.0
+pytest==4.6.9

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,7 +1,10 @@
 import os
 
+import docker
 import requests
 from pystemd.systemd1 import Unit
+
+WEB_APP_CONTAINER_NAME = 'beyond'
 
 
 def test_webserver_response_code():
@@ -19,3 +22,14 @@ def test_docker_deamon_is_running():
     unit = Unit(b'docker.service')
     unit.load()
     assert unit.Unit.ActiveState == b'active', "Docker deamon is not running"
+
+
+def test_docker_container_is_running():
+    """
+    Check that a given container name is running.
+    client.containers.list() is similar to 'docker ps'. it returns only running containers by default.
+    """
+    client = docker.from_env()
+    assert WEB_APP_CONTAINER_NAME in [con.name for con in client.containers.list()], (
+        f"Container {WEB_APP_CONTAINER_NAME} is not running."
+    )


### PR DESCRIPTION
fix #197 

In this PR the following was introduced:
- docker-compose.yml for building image named 'beyond' and running it
  with shell
- Vagrant file - adding 'vagrant-docker-compose' plugin, provisioning
  'docker-compose', rebuilding the image using the above yml and running
   the container.
- Added docker container test to check whether our container is up, and
  added the needed dependency for this to run.
- GitHub actions - adding a step for building and running our container
  with docker-compose.